### PR TITLE
Add Pix calculators and streamline comparison summaries

### DIFF
--- a/Nova pasta/index.html
+++ b/Nova pasta/index.html
@@ -154,25 +154,14 @@
     <button id="btn-toggle-parcelamento" onclick="toggleSeção('parcelamento-wrapper')">+ Parcelamento</button>
   </div>
 
-  <!-- QUADRANTES DE RESULTADO DAS TAXAS -->
+  <!-- QUADRANTE DE RESULTADO TOTAL DAS TAXAS -->
   <div id="resultado-taxas" class="resultado-taxas-box" style="display: none;">
-  <div class="quadrante-taxa visa">
-    <h4>💳 VISA</h4>
-    <p>Mensal: <strong>R$ <span id="visa-mensal">0,00</span></strong></p>
-    <p>Anual: <strong>R$ <span id="visa-anual">0,00</span></strong></p>
-  </div>
-
-  <div class="quadrante-taxa master">
-    <h4>💳 MASTER</h4>
-    <p>Mensal: <strong>R$ <span id="master-mensal">0,00</span></strong></p>
-    <p>Anual: <strong>R$ <span id="master-anual">0,00</span></strong></p>
-  </div>
-
-  <div class="quadrante-taxa elo">
-    <h4>💳 ELO</h4>
-    <p>Mensal: <strong>R$ <span id="elo-mensal">0,00</span></strong></p>
-    <p>Anual: <strong>R$ <span id="elo-anual">0,00</span></strong></p>
-  </div>
+    <div class="quadrante-taxa total">
+      <h4>📊 Resultado Total</h4>
+      <p>Diferença Mensal: <strong>R$ <span id="taxas-total-mensal">0,00</span></strong></p>
+      <p>Diferença Anual: <strong>R$ <span id="taxas-total-anual">0,00</span></strong></p>
+      <p id="taxas-mensagem-resumo" class="mensagem-resumo-taxas"></p>
+    </div>
   </div>
 
 </section>
@@ -582,7 +571,7 @@
   <table class="tabela-equipamentos">
     <thead>
       <tr>
-        <th>O QUE O CLIENTE TRARÁ NA NEGOCIAÇÃO</th>
+        <th>PRODUTOS / SERVIÇOS</th>
         <th>VOLUME MÊS (R$)</th>
         <th>VOLUME ANO (R$)</th>
       </tr>
@@ -604,6 +593,11 @@
         <td><input type="text" id="invest-pix-ano" disabled></td>
       </tr>
       <tr>
+        <td>Volume Pix na Maquininha</td>
+        <td><input type="number" id="invest-pix-maquininha" oninput="calcularInvestFacilParcial()"></td>
+        <td><input type="text" id="invest-pix-maquininha-ano" disabled></td>
+      </tr>
+      <tr>
         <td>Volume Pagamentos Diversos</td>
         <td><input type="number" id="invest-diversos" oninput="calcularInvestFacilParcial()"></td>
         <td><input type="text" id="invest-diversos-ano" disabled></td>
@@ -614,7 +608,7 @@
         <td><input type="text" id="invest-folha-ano" disabled></td>
       </tr>
       <tr>
-        <td><strong>Saldo</strong></td>
+        <td><strong>Saldo</strong><br><small class="nota-saldo">Sistema calcula automaticamente.</small></td>
         <td><input type="text" id="invest-saldo-mes" disabled></td>
         <td><input type="text" id="invest-saldo-ano" disabled></td>
       </tr>
@@ -651,50 +645,6 @@
 
 
 
-<!-- GDAD -->
-<section id="gdad-section" class="secao-calculo bg-gdad">
-  <h2>
-    <span>GDAD</span>
-    <span class="tooltip-wrapper">
-      <span class="tooltip-icon">i</span>
-      <span class="tooltip-text">
-        Este valor é calculado automaticamente com base no faturamento com cartões informado na seção <strong>Invest Fácil</strong>.<br><br>
-        Se R.A estiver marcado como <strong>Sim</strong>, o sistema aplica <strong>0,30%</strong> sobre o faturamento.<br>
-        Se R.A estiver como <strong>Não</strong>, aplica-se <strong>0,15%</strong>.<br><br>
-        O resultado representa o <strong>potencial estimado de retorno via GDAD</strong> em projeção mensal e anual.
-      </span>
-    </span>
-  </h2>
-
-  <form id="gdad-form">
-    <table class="tabela-equipamentos">
-      <thead>
-        <tr>
-          <th>DADO</th>
-          <th>VALOR (R$)</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Faturamento com Cartões</td>
-          <td><input type="text" id="gdad-faturamento" disabled></td>
-        </tr>
-        <tr>
-          <td><strong>Resultado GDAD Projetado (Mês)</strong></td>
-          <td><input type="text" id="gdad-mes" disabled></td>
-        </tr>
-        <tr>
-          <td><strong>Resultado GDAD Projetado (Ano)</strong></td>
-          <td><input type="text" id="gdad-ano" disabled></td>
-        </tr>
-      </tbody>
-    </table>
-  </form>
-</section>
-
-
-
-
 
 
 <!-- Resumo Final -->
@@ -704,67 +654,20 @@
   <span class="tooltip-wrapper">
     <span class="tooltip-icon">i</span>
     <span class="tooltip-text">
-      Este resumo consolida os resultados das seções anteriores: taxas, equipamentos, serviços e Invest Fácil.
-      Ele ajuda a visualizar a economia estimada mensal e anual com a proposta atual.
+      Este resumo reúne os principais resultados das seções anteriores e tem como objetivo facilitar a visualização da economia estimada,
+      tanto mensal quanto anual, com base nas informações cadastradas ao longo da proposta.
+
+      Ao final da análise:<br>
+      • Somamos as diferenças obtidas nas seções de Taxas e Equipamentos.<br>
+      • Consolidamos os ganhos das seções de Produtos/Serviços e de Produtos/Serviços do Pix.<br>
+      • Incorporamos o resultado da seção "O que o Cliente trará na negociação?".<br>
+
+      Por fim, agregamos o resultado do Invest Fácil e geramos o saldo final.
     </span>
   </span>
 </h2>
 
-  <!-- Linha 1: Taxas + Equipamentos -->
-  <div class="resumo-linha">
-    <div class="resumo-card bg-taxas">
-      <h4>💳 Comparativo de Taxas</h4>
-      <p id="resumo-taxas-mensal">Mensal: <strong>0</strong></p>
-      <p id="resumo-taxas-anual">Anual: <strong>0</strong></p>
-    </div>
-
-    <div class="resumo-card bg-equipamentos">
-      <h4>🖥️ Equipamentos</h4>
-      <p id="resumo-equip-qtd-cielo">Qtd. Cielo: <strong>0</strong></p>
-      <p id="resumo-equip-qtd-conc">Qtd. Conc.: <strong>0</strong></p>
-      <p id="resumo-equip-custo-cielo">Custo Cielo: <strong>0</strong></p>
-      <p id="resumo-equip-custo-conc">Custo Conc.: <strong>0</strong></p>
-      <p id="resumo-equip-dif-total"><strong>Diferença Total: 0</strong></p>
-    </div>
-  </div>
-
-  <!-- Linha 2: Serviços + Invest Fácil -->
-  <div class="resumo-linha">
-    <div class="resumo-card bg-servicos">
-      <h4>🧾 Produtos e Serviços</h4>
-      <p id="resumo-serv-qtd">Qtd. Transações: <strong>0</strong></p>
-      <p id="resumo-serv-atual">Atual: <strong>0</strong></p>
-      <p id="resumo-serv-proposto">Proposto: <strong>0</strong></p>
-      <p id="resumo-serv-mensal">Mensal: <strong>0</strong></p>
-      <p id="resumo-serv-anual">Anual: <strong>0</strong></p>
-      <p id="resumo-serv-dif"><strong>Diferença Média: 0.0%</strong></p>
-    </div>
-
-    <div class="resumo-card bg-invest">
-      <h4>📥 Invest Fácil</h4>
-      <p id="resumo-invest-repasse-mes">Repasse Mês: <strong>0</strong></p>
-      <p id="resumo-invest-repasse-ano">Repasse Anual: <strong>0</strong></p>
-      <p id="resumo-invest-incremento-mes">Incremento Mês: <strong>0</strong></p>
-      <p id="resumo-invest-incremento-ano">Incremento Anual: <strong>0</strong></p>
-    </div>
-  </div>
-
-  <!-- Linha 3: GDAD -->
-  <div class="resumo-linha">
-    <div class="resumo-card resumo-gdad bg-resumo">
-      <h4>📘 Resultado GDAD</h4>
-      <p>Resultado GDAD Projetado (Mensal): <strong>R$ <span id="resumo-gdad-mes">0,00</span></strong></p>
-      <p>Resultado GDAD Projetado (Anual): <strong>R$ <span id="resumo-gdad-ano">0,00</span></strong></p>
-    </div>
-  </div>
-
-  <!-- Resultado Total Final -->
-  <div id="bloco-resultado-total" class="resumo-cliente destaque-resultado-final" style="margin-top: 30px; text-align: center;">
-    <p style="font-size: 1.15rem; margin-bottom: 10px;">
-      Para o cliente <strong id="nome-cliente-final">"Cliente não informado"</strong>, o resultado total projetado considerando todas as seções é de:
-    </p>
-    <p id="valor-total-final" class="valor-total-final">R$ 0,00</p>
-  </div>
+  <p class="resumo-placeholder">Preencha as seções acima e clique em <strong>Calcular Resumo</strong> para visualizar o consolidado final.</p>
 </section>
 
 

--- a/Nova pasta/index.html
+++ b/Nova pasta/index.html
@@ -103,11 +103,12 @@
   </label>
 
 
-    <label style="display: block; margin-bottom: 10px; font-weight: bold;">Faturamento Total Mensal com Cartões (R$):
-      <input type="number" id="fat-mensal" placeholder="Ex: 50000" style="width: 100%; padding: 8px; margin-top: 5px;">
+    <label style="display: block; margin-bottom: 10px; font-weight: bold;">Faturamento mensal com Cartões (a ser negociado) - R$:
+      <input type="number" id="fat-mensal" placeholder="Ex: 50.000" style="width: 100%; padding: 8px; margin-top: 5px;">
     </label>
+    <p class="campo-ajuda" aria-live="polite">Valor a ser negociado passa ao Cliente.</p>
 
-    <label style="display: block; font-weight: bold;">Faturamento Total Anual com Cartões (R$):
+    <label style="display: block; font-weight: bold;">Faturamento total anual com Cartões (projeção) - R$:
       <input type="text" id="fat-anual" disabled style="width: 100%; padding: 8px; margin-top: 5px; background-color: #eaeaea;">
     </label> <br>
 
@@ -123,6 +124,8 @@
   <input type="radio" id="tipo-blindagem" name="tipo-cliente" value="Blindagem">
   <label for="tipo-blindagem">Blindagem</label>
 </div>
+
+    <div id="mensagem-tipo-cliente" class="alerta-tipo-cliente" aria-live="polite"></div>
 
     <div style="margin-top: 15px;">
     <label style="display: block; font-weight: bold; margin-bottom: 10px;">Recebíveis Antecipados (R.A)?</label>
@@ -245,15 +248,141 @@
 </section>
 
 
+<!-- Seção Pix na Maquininha -->
+<section class="pix-maquininha bg-servicos">
+  <h2>
+    <span>Pix na Maquininha</span>
+    <span class="tooltip-wrapper">
+      <span class="tooltip-icon">i</span>
+      <span class="tooltip-text">
+        Compare as tarifas atuais de Pix recebidas nas máquinas com a proposta Cielo.<br><br>
+        Informe o volume mensal em reais e as taxas praticadas para identificar o potencial de redução.
+      </span>
+    </span>
+  </h2>
+
+  <p class="descricao-secao">Abra quantas linhas desejar para detalhar cada produto Pix disponibilizado na maquininha.</p>
+
+  <form id="form-pix-maquininha">
+    <table class="tabela-equipamentos tabela-pix">
+      <thead>
+        <tr>
+          <th>Produto / Serviço</th>
+          <th>Volume Mês (R$)</th>
+          <th>Tarifa Atual (%)</th>
+          <th>Tarifa Proposta (%)</th>
+          <th>Redução Mês (R$)</th>
+          <th>Redução Ano (R$)</th>
+        </tr>
+      </thead>
+      <tbody id="pix-maquininha-tbody"></tbody>
+      <tfoot>
+        <tr>
+          <td><strong>Total</strong></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td class="bg-calculado"><span id="pix-maquininha-total-mes">0,00</span></td>
+          <td class="bg-calculado"><span id="pix-maquininha-total-ano">0,00</span></td>
+        </tr>
+      </tfoot>
+    </table>
+
+    <div class="form-actions linha-add">
+      <button type="button" class="add-btn azul" onclick="adicionarLinhaPixMaquininha()">+ Adicionar linha</button>
+    </div>
+
+    <div class="form-actions">
+      <button type="button" class="add-btn green" onclick="calcularPixMaquininha()">Calcular Pix na Maquininha</button>
+      <button type="button" class="add-btn red" onclick="limparPixMaquininha()">Limpar Pix na Maquininha</button>
+    </div>
+  </form>
+
+  <div id="resultado-pix-maquininha" class="resumo-pix" style="display: none;">
+    <div class="resumo-card bg-servicos">
+      <h4>📉 Redução Mensal</h4>
+      <p>R$ <span id="resumo-pix-maquininha-mes">0,00</span></p>
+    </div>
+    <div class="resumo-card bg-servicos">
+      <h4>📅 Redução Anual</h4>
+      <p>R$ <span id="resumo-pix-maquininha-ano">0,00</span></p>
+    </div>
+  </div>
+</section>
+
+
+<!-- Seção Demais Serviços Pix -->
+<section class="demais-servicos-pix bg-servicos">
+  <h2>
+    <span>Demais Serviços Pix</span>
+    <span class="tooltip-wrapper">
+      <span class="tooltip-icon">i</span>
+      <span class="tooltip-text">
+        Inclua tarifas de Pix que não são recebidas pela maquininha, como transferências e recebimentos por canais digitais.<br><br>
+        O sistema calcula automaticamente o impacto mensal e anual.
+      </span>
+    </span>
+  </h2>
+
+  <form id="form-demais-pix">
+    <table class="tabela-equipamentos tabela-pix">
+      <thead>
+        <tr>
+          <th>Serviço</th>
+          <th>Volume Mês (R$)</th>
+          <th>Qtd. Transações</th>
+          <th>Valor Atual (R$)</th>
+          <th>Valor Proposto (R$)</th>
+          <th>Redução Mês (R$)</th>
+          <th>Redução Ano (R$)</th>
+        </tr>
+      </thead>
+      <tbody id="demais-pix-tbody"></tbody>
+      <tfoot>
+        <tr>
+          <td><strong>Total</strong></td>
+          <td></td>
+          <td class="bg-calculado"><span id="demais-pix-total-qtd">0</span></td>
+          <td></td>
+          <td></td>
+          <td class="bg-calculado"><span id="demais-pix-total-mes">0,00</span></td>
+          <td class="bg-calculado"><span id="demais-pix-total-ano">0,00</span></td>
+        </tr>
+      </tfoot>
+    </table>
+
+    <div class="form-actions linha-add">
+      <button type="button" class="add-btn azul" onclick="adicionarLinhaDemaisPix()">+ Adicionar linha</button>
+    </div>
+
+    <div class="form-actions">
+      <button type="button" class="add-btn green" onclick="calcularDemaisServicosPix()">Calcular Serviços Pix</button>
+      <button type="button" class="add-btn red" onclick="limparDemaisServicosPix()">Limpar Serviços Pix</button>
+    </div>
+  </form>
+
+  <div id="resultado-demais-pix" class="resumo-pix" style="display: none;">
+    <div class="resumo-card bg-servicos">
+      <h4>📉 Redução Mensal</h4>
+      <p>R$ <span id="resumo-demais-pix-mes">0,00</span></p>
+    </div>
+    <div class="resumo-card bg-servicos">
+      <h4>📅 Redução Anual</h4>
+      <p>R$ <span id="resumo-demais-pix-ano">0,00</span></p>
+    </div>
+  </div>
+</section>
+
+
 <!-- Seção Serviços -->
 <section class="servicos bg-servicos">
   <h2>
   <h2>
-  <span><i class="fas fa-clipboard-list"></i> Produtos e Serviços</span>
+  <span><i class="fas fa-clipboard-list"></i> Produtos e Serviços Diversos</span>
   <span class="tooltip-wrapper">
     <span class="tooltip-icon">i</span>
     <span class="tooltip-text">
-      Esta seção compara os custos dos serviços cobrados atualmente com a proposta da Cielo. <br><br>
+      Esta seção compara os custos dos serviços gerais com a proposta da Cielo. <br><br>
        <strong>Como calculamos:</strong><br>
       • Subtraímos o valor proposto do valor atual (Atual - Proposto).<br>
       • Multiplicamos essa diferença pela quantidade de transações para saber a economia mensal.<br>
@@ -349,6 +478,85 @@
 
 
 
+
+
+
+
+<!-- Seção Produtos e Serviços Consolidados -->
+<section class="servicos-consolidados bg-servicos">
+  <h2>
+    <span>Produtos e Serviços Consolidados</span>
+    <span class="tooltip-wrapper">
+      <span class="tooltip-icon">i</span>
+      <span class="tooltip-text">
+        Some os resultados dos blocos de Produtos e Serviços Diversos, Pix na Maquininha e Demais Serviços Pix.
+        Assim você visualiza o impacto mensal e anual completo que será apresentado ao cliente.
+      </span>
+    </span>
+  </h2>
+
+  <p class="descricao-secao">Sistema calculará o valor "no mês" e "no ano", conforme abaixo.</p>
+
+  <div id="resultado-consolidado" class="resumo-pix" style="display: none;">
+    <div class="resumo-card bg-servicos">
+      <h4>📉 Redução Mensal Consolidada</h4>
+      <p>R$ <span id="consolidado-mensal">0,00</span></p>
+    </div>
+    <div class="resumo-card bg-servicos">
+      <h4>📅 Redução Anual Consolidada</h4>
+      <p>R$ <span id="consolidado-anual">0,00</span></p>
+    </div>
+  </div>
+
+  <div class="form-actions">
+    <button type="button" class="add-btn green" onclick="calcularConsolidado()">Calcular Redução Consolidada</button>
+    <button type="button" class="add-btn red" onclick="limparConsolidado()">Limpar Consolidação</button>
+  </div>
+</section>
+
+
+<!-- Seção O que o Cliente trará na negociação -->
+<section class="negociacao-cliente bg-servicos">
+  <h2>
+    <span>O que o Cliente trará na negociação?</span>
+    <span class="tooltip-wrapper">
+      <span class="tooltip-icon">i</span>
+      <span class="tooltip-text">
+        Utilize esta tabela para registrar os volumes que serão negociados com o cliente.
+        Ao informar o valor mensal, o sistema projeta automaticamente o valor anual.
+      </span>
+    </span>
+  </h2>
+
+  <form id="form-negociacao">
+    <table class="tabela-equipamentos tabela-pix">
+      <thead>
+        <tr>
+          <th>Item</th>
+          <th>Volume Mês (R$)</th>
+          <th>Volume Ano (R$)</th>
+        </tr>
+      </thead>
+      <tbody id="negociacao-tbody"></tbody>
+      <tfoot>
+        <tr>
+          <td><strong>Total</strong></td>
+          <td class="bg-calculado"><span id="negociacao-total-mes">0,00</span></td>
+          <td class="bg-calculado"><span id="negociacao-total-ano">0,00</span></td>
+        </tr>
+      </tfoot>
+    </table>
+
+    <div class="form-actions linha-add">
+      <button type="button" class="add-btn azul" onclick="adicionarLinhaNegociacao()">+ Adicionar item</button>
+    </div>
+
+    <div class="form-actions">
+      <button type="button" class="add-btn green" onclick="calcularNegociacao()">Calcular Volumes</button>
+      <button type="button" class="add-btn red" onclick="limparNegociacao()">Limpar Itens</button>
+    </div>
+  </form>
+</section>
 
 
 <!-- Seção Invest Fácil – Projeção com Conquista de Caixa -->

--- a/Nova pasta/script.js
+++ b/Nova pasta/script.js
@@ -857,10 +857,11 @@ function calcularInvestFacilParcial() {
   const fatCartao = get("invest-fat");
   const boletos = get("invest-boletos");
   const pix = get("invest-pix");
+  const pixMaquininha = get("invest-pix-maquininha");
   const diversos = get("invest-diversos");
   const folha = get("invest-folha");
 
-  const entrada = fatCartao + boletos + pix;
+  const entrada = fatCartao + boletos + pix + pixMaquininha;
   const saida = diversos + folha;
   const saldoMes = entrada - saida;
   const saldoAno = saldoMes * 12;
@@ -868,6 +869,7 @@ function calcularInvestFacilParcial() {
   setValueIfExists("invest-fat-ano", fatCartao * 12);
   setValueIfExists("invest-boletos-ano", boletos * 12);
   setValueIfExists("invest-pix-ano", pix * 12);
+  setValueIfExists("invest-pix-maquininha-ano", pixMaquininha * 12);
   setValueIfExists("invest-diversos-ano", diversos * 12);
   setValueIfExists("invest-folha-ano", folha * 12);
   setValueIfExists("invest-saldo-mes", saldoMes);
@@ -877,7 +879,7 @@ function calcularInvestFacilParcial() {
 // Exibe os quadrantes de saldo e resultado projetado
 function calcularInvestFacil() {
   const saldoEl = document.getElementById("invest-saldo-mes");
-  const saldo = saldoEl ? parseFloat(saldoEl.value.replace(".", "").replace(",", ".")) : 0;
+  const saldo = saldoEl ? parseFloat(saldoEl.value.replace(/\./g, "").replace(",", ".")) || 0 : 0;
 
   const repasseMes = saldo * 0.0136;
   const repasseAno = repasseMes * 12;
@@ -922,61 +924,9 @@ function limparInvestFacil() {
 
 
 
-// ===============================
-// GDAD
-// ===============================
-
-function calcularGdadAutomaticamente() {
-  const inputFaturamento = document.getElementById("invest-fat");
-  const gdadFaturamento = document.getElementById("gdad-faturamento");
-  const gdadMes = document.getElementById("gdad-mes");
-  const gdadAno = document.getElementById("gdad-ano");
-
-  if (!inputFaturamento || !gdadFaturamento || !gdadMes || !gdadAno) return;
-
-  const valorFaturamento = parseFloat(inputFaturamento.value || 0);
-
-  // Atualiza campo de exibição de faturamento
-  gdadFaturamento.value = valorFaturamento.toLocaleString("pt-BR", {
-    style: "currency",
-    currency: "BRL"
-  });
-
-  // Verifica se R.A está marcado
-  const isRaSim = document.getElementById("ra-sim")?.checked;
-  const isRaNao = document.getElementById("ra-nao")?.checked;
-
-  // Só calcula se alguma opção estiver marcada
-  if (isRaSim || isRaNao) {
-    const percentual = isRaSim ? 0.003 : 0.0015;
-    const valorMensal = valorFaturamento * percentual;
-    const valorAnual = valorMensal * 12;
-
-    gdadMes.value = valorMensal.toLocaleString("pt-BR", {
-      style: "currency",
-      currency: "BRL"
-    });
-
-    gdadAno.value = valorAnual.toLocaleString("pt-BR", {
-      style: "currency",
-      currency: "BRL"
-    });
-  } else {
-    gdadMes.value = "";
-    gdadAno.value = "";
-  }
-}
-
-// Atualiza GDAD sempre que o faturamento ou R.A for alterado
-document.getElementById("invest-fat")?.addEventListener("input", calcularGdadAutomaticamente);
-document.getElementById("ra-sim")?.addEventListener("change", calcularGdadAutomaticamente);
-document.getElementById("ra-nao")?.addEventListener("change", calcularGdadAutomaticamente);
-
-
-
-// ===============================
-// RESUMO FINAL
-// ===============================
+  // ===============================
+  // RESUMO FINAL
+  // ===============================
 
 function formatarMoedaResumo(valor) {
   return valor.toLocaleString("pt-BR", {
@@ -1001,219 +951,240 @@ function calcularResumoFinal() {
     gruposValidos.push(`parcelamento-${i}`);
   }
 
-  let totalMensalTaxas = 0, totalAnualTaxas = 0;
-  let totalCustoCieloMensal = 0, totalCustoConcMensal = 0;
+  let totalMensalTaxas = 0;
+  let totalAnualTaxas = 0;
+  let totalCustoCieloMensal = 0;
+  let totalCustoConcMensal = 0;
 
   gruposValidos.forEach(grupo => {
     const bandeiras = grupo === "debito" ? ["visa", "master", "elo"] : ["visa", "master", "elo", "amex", "hiper"];
     bandeiras.forEach(b => {
-      const f = parseFloat(document.querySelector(`[name='${grupo}-faturamento-${b}']`)?.value || 0);
-      const tCielo = parseFloat(document.querySelector(`[name='${grupo}-taxaCielo-${b}']`)?.value || 0);
-      const tConc = parseFloat(document.querySelector(`[name='${grupo}-taxaConc-${b}']`)?.value || 0);
-      totalCustoCieloMensal += (f * tCielo) / 100;
-      totalCustoConcMensal += (f * tConc) / 100;
-      totalMensalTaxas += (f * (tConc - tCielo)) / 100;
-      totalAnualTaxas += (f * (tConc - tCielo)) / 100 * 12;
+      const faturamento = parseFloat(document.querySelector(`[name='${grupo}-faturamento-${b}']`)?.value || 0);
+      const taxaCielo = parseFloat(document.querySelector(`[name='${grupo}-taxaCielo-${b}']`)?.value || 0);
+      const taxaConc = parseFloat(document.querySelector(`[name='${grupo}-taxaConc-${b}']`)?.value || 0);
+
+      totalCustoCieloMensal += (faturamento * taxaCielo) / 100;
+      totalCustoConcMensal += (faturamento * taxaConc) / 100;
+      totalMensalTaxas += (faturamento * (taxaConc - taxaCielo)) / 100;
+      totalAnualTaxas += (faturamento * (taxaConc - taxaCielo)) / 100 * 12;
     });
   });
 
   const custoCieloAnual = totalCustoCieloMensal * 12;
   const custoConcAnual = totalCustoConcMensal * 12;
 
-  const campos = ["zip", "flash", "lio", "tef"];
-  let qtdCielo = 0, qtdConc = 0, custoCielo = 0, custoConc = 0;
+  const formatarNumero = valor => formatarMoedaResumo(isNaN(valor) ? 0 : valor);
+  const formatarComSinal = valor => `${valor >= 0 ? "" : "-"}${formatarNumero(Math.abs(valor))}`;
 
-  campos.forEach(c => {
-    const qC = parseInt(document.querySelector(`[name='qtd-${c}']`)?.value || 0);
-    const qX = parseInt(document.querySelector(`[name='qtdc-${c}']`)?.value || 0);
-    const vC = parseFloat(document.querySelector(`[name='cielo-${c}']`)?.value || 0);
-    const vX = parseFloat(document.querySelector(`[name='conc-${c}']`)?.value || 0);
-    qtdCielo += qC;
-    qtdConc += qX;
-    custoCielo += qC * vC;
-    custoConc += qX * vX;
+  const resultadoTaxas = document.getElementById("resultado-taxas");
+  if (resultadoTaxas) {
+    const spanMensal = document.getElementById("taxas-total-mensal");
+    const spanAnual = document.getElementById("taxas-total-anual");
+    const mensagem = document.getElementById("taxas-mensagem-resumo");
+
+    if (spanMensal) spanMensal.textContent = formatarComSinal(totalMensalTaxas);
+    if (spanAnual) spanAnual.textContent = formatarComSinal(totalAnualTaxas);
+
+    if (mensagem) {
+      if (totalAnualTaxas === 0) {
+        mensagem.textContent = "As propostas apresentam o mesmo custo anual.";
+      } else if (totalAnualTaxas > 0) {
+        mensagem.textContent = `A taxa do concorrente anual gera R$ ${formatarNumero(Math.abs(totalAnualTaxas))} a mais que a da Cielo.`;
+      } else {
+        mensagem.textContent = `A taxa do concorrente anual gera R$ ${formatarNumero(Math.abs(totalAnualTaxas))} a menos que a da Cielo.`;
+      }
+    }
+
+    const mostrarTaxas = Math.abs(totalCustoCieloMensal) > 0 || Math.abs(totalCustoConcMensal) > 0;
+    resultadoTaxas.style.display = mostrarTaxas ? "flex" : "none";
+  }
+
+  const camposEquip = ["zip", "flash", "lio", "tef"];
+  let qtdCielo = 0;
+  let qtdConc = 0;
+  let custoCielo = 0;
+  let custoConc = 0;
+
+  camposEquip.forEach(campo => {
+    const qtdC = parseInt(document.querySelector(`[name='qtd-${campo}']`)?.value || 0);
+    const qtdK = parseInt(document.querySelector(`[name='qtdc-${campo}']`)?.value || 0);
+    const valorC = parseFloat(document.querySelector(`[name='cielo-${campo}']`)?.value || 0);
+    const valorK = parseFloat(document.querySelector(`[name='conc-${campo}']`)?.value || 0);
+
+    qtdCielo += qtdC;
+    qtdConc += qtdK;
+    custoCielo += qtdC * valorC;
+    custoConc += qtdK * valorK;
   });
 
-  const difEquip = custoConc - custoCielo;
+  const diferencaEquipMensal = custoConc - custoCielo;
+  const diferencaEquipAnual = diferencaEquipMensal * 12;
 
-  const atualServ = parseFloat((document.getElementById("total-atual")?.textContent || "0").replace(/\./g, "").replace(",", "."));
-  const propServ = parseFloat((document.getElementById("total-proposto")?.textContent || "0").replace(/\./g, "").replace(",", "."));
-  const mesServ = parseFloat((document.getElementById("total-mes")?.textContent || "0").replace(/\./g, "").replace(",", "."));
+  const parseNumeroTexto = (texto) => {
+    if (!texto) return 0;
+    const normalizado = texto.toString().replace(/\./g, "").replace(/[^0-9,-]/g, "").replace(",", ".");
+    const numero = parseFloat(normalizado);
+    return isNaN(numero) ? 0 : numero;
+  };
+
+  const atualServ = parseNumeroTexto(document.getElementById("total-atual")?.textContent);
+  const propServ = parseNumeroTexto(document.getElementById("total-proposto")?.textContent);
+  const mesServ = parseNumeroTexto(document.getElementById("total-mes")?.textContent);
 
   const totalServicosMensal = totaisSecoes.servicosDiversos.mensal + totaisSecoes.pixMaquininha.mensal + totaisSecoes.demaisPix.mensal;
   const totalServicosAnual = totaisSecoes.servicosDiversos.anual + totaisSecoes.pixMaquininha.anual + totaisSecoes.demaisPix.anual;
 
-  const pegarTextoSpan = id => parseFloat((document.getElementById(id)?.textContent || "0").replace(/\./g, "").replace(",", "."));
+  const pegarTextoSpan = id => parseNumeroTexto(document.getElementById(id)?.textContent);
   const repM = pegarTextoSpan("repasse-mes");
   const repA = pegarTextoSpan("repasse-ano");
   const incM = pegarTextoSpan("incremento-mes");
   const incA = pegarTextoSpan("incremento-ano");
 
-  const limparInputComRS = id => {
-    const el = document.getElementById(id);
-    if (!el) return 0;
-    const texto = el.value.replace(/[^\d,]/g, "").replace(",", ".");
-    return parseFloat(texto || 0);
-  };
+  const negociacaoMensal = parseNumeroTexto(document.getElementById("negociacao-total-mes")?.textContent);
+  const negociacaoAnual = parseNumeroTexto(document.getElementById("negociacao-total-ano")?.textContent);
 
-  const gdadMes = limparInputComRS("gdad-mes");
-  const gdadAno = limparInputComRS("gdad-ano");
+  const economiaMensalCliente = totalMensalTaxas + diferencaEquipMensal + totalServicosMensal;
+  const economiaAnualCliente = totalAnualTaxas + diferencaEquipAnual + totalServicosAnual;
 
-  const cliente_mensal = totalMensalTaxas + difEquip - totalServicosMensal;
-  const cliente_anual = (totalMensalTaxas * 12) + difEquip - totalServicosAnual;
+  const resultadoMensalComInvest = economiaMensalCliente + incM;
+  const resultadoAnualComInvest = economiaAnualCliente + incA;
 
   const empresa = document.getElementById("nome-empresa")?.value || "Cliente não informado";
+  const classeValorTotal = resultadoAnualComInvest === 0 ? "neutro" : (resultadoAnualComInvest > 0 ? "positivo" : "negativo");
 
-  const classeValorTotal = cliente_mensal === 0 ? "neutro" : (cliente_mensal < 0 ? "positivo" : "negativo");
+  const mensagemTaxaAnual = totalAnualTaxas === 0
+    ? "As propostas apresentam o mesmo custo anual."
+    : totalAnualTaxas > 0
+      ? `A taxa do concorrente anual gera R$ ${formatarNumero(Math.abs(totalAnualTaxas))} a mais que a da Cielo.`
+      : `A taxa do concorrente anual gera R$ ${formatarNumero(Math.abs(totalAnualTaxas))} a menos que a da Cielo.`;
+
+  const economiaClienteDescricao = economiaMensalCliente >= 0 ? "economia" : "aumento";
+  const diferencaLiquida = incM - economiaMensalCliente;
+  const classificacaoBanco = diferencaLiquida >= 0
+    ? '<strong style="color: green;">vantajosa para o banco</strong>'
+    : '<strong style="color: red;">menos vantajosa para o banco</strong>';
+
+  const resumoGrupo = document.getElementById("visao-grupo")?.checked ? (() => {
+    const getListItems = (selector) =>
+      [...document.querySelectorAll(selector)]
+        .map(el => `<li>${el.childNodes[0].textContent.trim()}</li>`)
+        .join("");
+
+    const cnpjs = getListItems("#lista-cnpjs .composicao-item");
+    const agencias = getListItems("#lista-agencias .composicao-item");
+    const contas = getListItems("#lista-contas .composicao-item");
+
+    if (!cnpjs && !agencias && !contas) return "";
+
+    return `
+      <div class="resumo-cliente destaque-resultado-final" style="margin-top: 30px; text-align: center;">
+        <p style=\"font-size: 1rem; margin-bottom: 12px;\">Composição informada para o grupo econômico:</p>
+        <div class=\"resumo-grupo-container\">
+          ${cnpjs ? `
+            <div class=\"resumo-grupo-card\">
+              <h4>📄 CNPJs do Grupo</h4>
+              <ul>${cnpjs}</ul>
+            </div>` : ""}
+          ${agencias ? `
+            <div class=\"resumo-grupo-card\">
+              <h4>🏦 Agências</h4>
+              <ul>${agencias}</ul>
+            </div>` : ""}
+          ${contas ? `
+            <div class=\"resumo-grupo-card\">
+              <h4>💳 Contas</h4>
+              <ul>${contas}</ul>
+            </div>` : ""}
+        </div>
+      </div>
+    `;
+  })() : "";
 
   const html = `
-  <div id="bloco-resultado-total" class="resumo-cliente destaque-resultado-final" style="margin-bottom: 24px; text-align: center;">
-    <p style="font-size: 1.1rem; margin-bottom: 10px;">
-      Para o cliente <strong id="nome-cliente-final">${empresa}</strong>, o resultado total projetado considerando todas as seções é:
-    </p>
-    <p id="valor-total-final" class="valor-total-final ${classeValorTotal}">R$ ${formatarMoedaResumo(Math.abs(cliente_anual))}</p>
-  </div>
-
-  <div class="resumo-linha">
-    <div class="resumo-card bg-taxas">
-      <h4>📊 Comparativo de Taxas</h4>
-      <p>Custo Cielo Mensal: <strong>${formatarMoedaResumo(totalCustoCieloMensal)}</strong></p>
-      <p>Custo Concorrente Mensal: <strong>${formatarMoedaResumo(totalCustoConcMensal)}</strong></p>
-      <p>Custo Cielo Anual: <strong>${formatarMoedaResumo(custoCieloAnual)}</strong></p>
-      <p>Custo Concorrente Anual: <strong>${formatarMoedaResumo(custoConcAnual)}</strong></p>
-      <p style="margin-top: 10px;">
-        A Cielo tem um custo <strong>${totalMensalTaxas >= 0 ? "menor" : "maior"}</strong> que o concorrente de 
-        <strong>${formatarMoedaResumo(Math.abs(totalMensalTaxas))}</strong> por mês.
+    <div id="bloco-resultado-total" class="resumo-cliente destaque-resultado-final" style="margin-bottom: 24px; text-align: center;">
+      <p style="font-size: 1.1rem; margin-bottom: 10px;">
+        Para o cliente <strong id="nome-cliente-final">${empresa}</strong>, o resultado total projetado considerando todas as seções é:
       </p>
+      <p id="valor-total-final" class="valor-total-final ${classeValorTotal}">R$ ${formatarNumero(Math.abs(resultadoAnualComInvest))}</p>
+      <p class="texto-mensal-equivalente">Equivalente a R$ ${formatarNumero(Math.abs(resultadoMensalComInvest))} por mês.</p>
     </div>
 
-    <div class="resumo-card bg-equipamentos">
-      <h4>🖥️ Equipamentos</h4>
-      <p>Qtd. Cielo: <strong>${qtdCielo}</strong></p>
-      <p>Qtd. Conc.: <strong>${qtdConc}</strong></p>
-      <p>Custo Mensal Cielo: <strong>${formatarMoedaResumo(custoCielo)}</strong></p>
-      <p>Custo Mensal Concorrente: <strong>${formatarMoedaResumo(custoConc)}</strong></p>
-      <p>Custo Anual Cielo: <strong>${formatarMoedaResumo(custoCielo * 12)}</strong></p>
-      <p>Custo Anual Concorrente: <strong>${formatarMoedaResumo(custoConc * 12)}</strong></p>
-      <p style="margin-top: 10px;">
-        A Cielo tem um custo <strong>${custoCielo < custoConc ? "menor" : "maior"}</strong> que o concorrente de 
-        <strong>${formatarMoedaResumo(Math.abs(custoCielo - custoConc))}</strong> por mês.
-      </p>
-    </div>
-  </div>
+    <div class="resumo-linha">
+      <div class="resumo-card bg-taxas">
+        <h4>💳 Comparativo de Taxas</h4>
+        <p>Custo Mensal Cielo: <strong>R$ ${formatarNumero(totalCustoCieloMensal)}</strong></p>
+        <p>Custo Mensal Concorrente: <strong>R$ ${formatarNumero(totalCustoConcMensal)}</strong></p>
+        <p>Custo Anual Cielo: <strong>R$ ${formatarNumero(custoCieloAnual)}</strong></p>
+        <p>Custo Anual Concorrente: <strong>R$ ${formatarNumero(custoConcAnual)}</strong></p>
+        <p class="destaque-diferenca">Economia Mensal: <strong>R$ ${formatarNumero(Math.abs(totalMensalTaxas))}</strong> (${totalMensalTaxas >= 0 ? "Cielo mais competitiva" : "Concorrente mais competitivo"}).</p>
+        <p class="mensagem-comparativo">${mensagemTaxaAnual}</p>
+      </div>
 
-  <div class="resumo-linha">
-    <div class="resumo-card bg-servicos">
-      <h4>🧾 Produtos e Serviços</h4>
-      <p>Custo Atual (Diversos): <strong>${formatarMoedaResumo(atualServ)}</strong></p>
-      <p>Custo Proposto (Diversos): <strong>${formatarMoedaResumo(propServ)}</strong></p>
-      <p>Redução Diversos (Mês): <strong>${formatarMoedaResumo(mesServ)}</strong></p>
-      <p>Pix na Maquininha (Mês): <strong>${formatarMoedaResumo(totaisSecoes.pixMaquininha.mensal)}</strong></p>
-      <p>Demais Serviços Pix (Mês): <strong>${formatarMoedaResumo(totaisSecoes.demaisPix.mensal)}</strong></p>
-      <p><strong>Total Mensal Consolidado: ${formatarMoedaResumo(totalServicosMensal)}</strong></p>
-      <p><strong>Total Anual Consolidado: ${formatarMoedaResumo(totalServicosAnual)}</strong></p>
-      <p style="margin-top: 10px;">
-        A proposta apresenta uma <strong>${totalServicosMensal >= 0 ? "redução" : "elevação"}</strong> de
-        <strong>${formatarMoedaResumo(Math.abs(totalServicosMensal))}</strong> por mês considerando todos os serviços.
-      </p>
+      <div class="resumo-card bg-equipamentos">
+        <h4>🖥️ Equipamentos</h4>
+        <p>Qtd. Cielo: <strong>${qtdCielo}</strong></p>
+        <p>Qtd. Concorrente: <strong>${qtdConc}</strong></p>
+        <p>Custo Mensal Cielo: <strong>R$ ${formatarNumero(custoCielo)}</strong></p>
+        <p>Custo Mensal Concorrente: <strong>R$ ${formatarNumero(custoConc)}</strong></p>
+        <p>Diferença Mensal: <strong>R$ ${formatarNumero(Math.abs(diferencaEquipMensal))}</strong> (${diferencaEquipMensal >= 0 ? "Cielo mais competitiva" : "Concorrente mais competitivo"}).</p>
+        <p>Diferença Anual: <strong>R$ ${formatarNumero(Math.abs(diferencaEquipAnual))}</strong></p>
+      </div>
     </div>
 
-    <div class="resumo-card bg-invest">
-      <h4>📅 Invest Fácil</h4>
-      <p>Saldo Médio Projetado Mensal: <strong>${formatarMoedaResumo(repM)}</strong></p>
-      <p>Saldo Médio Projetado Anual: <strong>${formatarMoedaResumo(repA)}</strong></p>
-      <p>Resultado Projetado Mensal: <strong>${formatarMoedaResumo(incM)}</strong></p>
-      <p>Resultado Projetado Anual: <strong>${formatarMoedaResumo(incA)}</strong></p>
-      <p style="margin-top: 10px;">
-        O Invest Fácil poderá gerar um <strong>acréscimo</strong> de 
-        <strong>${formatarMoedaResumo(incM)}</strong> por mês em resultado projetado.
-      </p>
+    <div class="resumo-linha">
+      <div class="resumo-card bg-servicos">
+        <h4>🧾 Produtos e Serviços Consolidados</h4>
+        <p>Serviços Diversos (Mês): <strong>R$ ${formatarNumero(mesServ)}</strong></p>
+        <p>Pix na Maquininha (Mês): <strong>R$ ${formatarNumero(totaisSecoes.pixMaquininha.mensal)}</strong></p>
+        <p>Demais Serviços Pix (Mês): <strong>R$ ${formatarNumero(totaisSecoes.demaisPix.mensal)}</strong></p>
+        <p class="destaque-diferenca">Total Economia Mensal: <strong>R$ ${formatarNumero(totalServicosMensal)}</strong></p>
+        <p>Total Economia Anual: <strong>R$ ${formatarNumero(totalServicosAnual)}</strong></p>
+      </div>
+
+      <div class="resumo-card bg-servicos negociacao-card">
+        <h4>📦 O que o Cliente trará na negociação?</h4>
+        <p>Total Mensal: <strong>R$ ${formatarNumero(negociacaoMensal)}</strong></p>
+        <p>Total Anual: <strong>R$ ${formatarNumero(negociacaoAnual)}</strong></p>
+      </div>
     </div>
-  </div>
 
-  <div class="resumo-linha">
-    <div class="resumo-card resumo-gdad bg-resumo">
-      <h4>📘 Resultado GDAD</h4>
-      <p>Resultado GDAD Projetado (Mensal): <strong>${formatarMoedaResumo(gdadMes)}</strong></p>
-      <p>Resultado GDAD Projetado (Anual): <strong>${formatarMoedaResumo(gdadAno)}</strong></p>
+    <div class="resumo-linha">
+      <div class="resumo-card bg-invest">
+        <h4>📅 Invest Fácil</h4>
+        <p>Saldo Médio Projetado (Mês): <strong>R$ ${formatarNumero(repM)}</strong></p>
+        <p>Saldo Médio Projetado (Ano): <strong>R$ ${formatarNumero(repA)}</strong></p>
+        <p>Resultado Projetado (Mês): <strong>R$ ${formatarNumero(incM)}</strong></p>
+        <p>Resultado Projetado (Ano): <strong>R$ ${formatarNumero(incA)}</strong></p>
+        <p class="mensagem-comparativo">O Invest Fácil pode adicionar R$ ${formatarNumero(incM)} por mês em resultado projetado.</p>
+      </div>
     </div>
-  </div>
 
-  ${
-    document.getElementById("visao-grupo")?.checked ? (() => {
-      const getListItems = (selector) =>
-        [...document.querySelectorAll(selector)]
-          .map(el => `<li>${el.childNodes[0].textContent.trim()}</li>`)
-          .join("");
+    ${resumoGrupo}
 
-      const cnpjs = getListItems("#lista-cnpjs .composicao-item");
-      const agencias = getListItems("#lista-agencias .composicao-item");
-      const contas = getListItems("#lista-contas .composicao-item");
-
-      if (!cnpjs && !agencias && !contas) return "";
-
-      return `
-        <div class="resumo-cliente destaque-resultado-final" style="margin-top: 30px; text-align: center;">
-          <p style=\"font-size: 1rem; margin-bottom: 12px;\">Composição informada para o grupo econômico:</p>
-          <div class=\"resumo-grupo-container\">
-            ${cnpjs ? `
-              <div class=\"resumo-grupo-card\">
-                <h4>📄 CNPJs do Grupo</h4>
-                <ul>${cnpjs}</ul>
-              </div>` : ""}
-            ${agencias ? `
-              <div class=\"resumo-grupo-card\">
-                <h4>🏦 Agências</h4>
-                <ul>${agencias}</ul>
-              </div>` : ""}
-            ${contas ? `
-              <div class=\"resumo-grupo-card\">
-                <h4>💳 Contas</h4>
-                <ul>${contas}</ul>
-              </div>` : ""}
-          </div>
-        </div>
-      `;
-    })() : ""
-  }
-
-  <div class="resumo-linha">
+    <div class="resumo-linha">
       <div class="resumo-card bg-servicos">
         <h4>👤 Visão do Cliente</h4>
-        <p><strong>Custo Final:</strong> Houve uma ${cliente_mensal < 0 ? "redução" : "elevação"} de 
-        <strong>${formatarMoedaResumo(Math.abs(cliente_mensal))}</strong> por mês e 
-        <strong>${formatarMoedaResumo(Math.abs(cliente_anual))}</strong> por ano.</p>
+        <p>Economia Mensal Projetada: <strong>R$ ${formatarNumero(Math.abs(economiaMensalCliente))}</strong> (${economiaClienteDescricao}).</p>
+        <p>Economia Anual Projetada: <strong>R$ ${formatarNumero(Math.abs(economiaAnualCliente))}</strong>.</p>
       </div>
 
       <div class="resumo-card bg-invest">
         <h4>🏦 Visão do Banco</h4>
-        <p><strong>Resultado Projetado:</strong> Estima-se um acréscimo de 
-        <strong>${formatarMoedaResumo(incM + gdadMes)}</strong> por mês e 
-        <strong>${formatarMoedaResumo(incA + gdadAno)}</strong> por ano com Invest Fácil + GDAD.</p>
+        <p>Resultado Mensal Invest Fácil: <strong>R$ ${formatarNumero(incM)}</strong></p>
+        <p>Resultado Anual Invest Fácil: <strong>R$ ${formatarNumero(incA)}</strong></p>
       </div>
     </div>
 
     <div class="resumo-cliente destaque-resultado-final" style="margin-top: 20px; text-align: center;">
-      ${(() => {
-        const diferencaLiquida = (incM + gdadMes) - cliente_mensal;
-        const classificacao = diferencaLiquida > 0 
-          ? '<strong style="color: green;">vantajosa para o banco</strong>' 
-          : '<strong style="color: red;">menos vantajosa para o banco</strong>';
-        return `
-          <p style="font-size: 1.1rem;">
-            A proposta apresenta uma diferença líquida de 
-            <strong>${formatarMoedaResumo(Math.abs(diferencaLiquida))}</strong> por mês, sendo considerada ${classificacao}.
-          </p>
-        `;
-      })()}
+      <p style="font-size: 1.05rem;">
+        A diferença líquida entre o potencial do banco e a economia entregue ao cliente é de
+        <strong>R$ ${formatarNumero(Math.abs(diferencaLiquida))}</strong> por mês,
+        sendo considerada ${classificacaoBanco}.
+      </p>
     </div>
-  </div>
-`;
+  `;
 
-
-
-
-   const resultado = document.getElementById("resumo-final");
+  const resultado = document.getElementById("resumo-final");
   if (resultado) {
     const titulo = resultado.querySelector("h2");
     const tituloClonado = titulo?.cloneNode(true);

--- a/Nova pasta/script.js
+++ b/Nova pasta/script.js
@@ -139,7 +139,9 @@ function calcularLinha(grupo, bandeira) {
     custoCielo,
     custoConc,
     diffReais,
-    faturamento
+    faturamento,
+    taxaCielo,
+    taxaConc
   };
 }
 
@@ -147,53 +149,59 @@ function calcularLinha(grupo, bandeira) {
 
 function calcularResumo(grupo) {
   const listaBandeiras = grupo === "debito" ? ["visa", "master", "elo"] : [...bandeiras];
-  const resultados = listaBandeiras.map(b => calcularLinha(grupo, b));
-
+  let totalCustoCieloMensal = 0;
+  let totalCustoConcMensal = 0;
   let totalMensal = 0;
-  let totalAnual = 0;
+  let totalFaturamento = 0;
+  let somaTarifaCielo = 0;
+  let somaTarifaConc = 0;
 
-  let html = `<div class="resumo-taxas-matriz">`;
-
-  resultados.forEach(r => {
-    const mensalCielo = r.custoCielo;
-    const mensalConc = r.custoConc;
-    const diffMensal = mensalConc - mensalCielo;
-
-    const anualCielo = mensalCielo * 12;
-    const anualConc = mensalConc * 12;
-    const diffAnual = anualConc - anualCielo;
-
-    totalMensal += diffMensal;
-    totalAnual += diffAnual;
-
-    const corMensal = diffMensal >= 0 ? "positivo" : "negativo";
-    const corAnual = diffAnual >= 0 ? "positivo" : "negativo";
-
-    html += `
-      <div class="card-taxa-detalhado">
-        <img src="img/${r.bandeira}.png" alt="${r.bandeira.toUpperCase()}" />
-        <span>${r.bandeira.toUpperCase()}</span>
-        <p>Mensal Cielo: R$ ${mensalCielo.toFixed(2)}</p>
-        <p>Mensal Concorrente: R$ ${mensalConc.toFixed(2)}</p>
-        <p class="valor ${corMensal}">Diferença Mensal: ${diffMensal >= 0 ? "+" : "–"}R$ ${Math.abs(diffMensal).toFixed(2)}</p>
-        <hr>
-        <p>Anual Cielo: R$ ${anualCielo.toFixed(2)}</p>
-        <p>Anual Concorrente: R$ ${anualConc.toFixed(2)}</p>
-        <p class="valor ${corAnual}">Diferença Anual: ${diffAnual >= 0 ? "+" : "–"}R$ ${Math.abs(diffAnual).toFixed(2)}</p>
-      </div>
-    `;
+  listaBandeiras.forEach(b => {
+    const resultado = calcularLinha(grupo, b);
+    totalCustoCieloMensal += resultado.custoCielo;
+    totalCustoConcMensal += resultado.custoConc;
+    totalMensal += resultado.custoConc - resultado.custoCielo;
+    totalFaturamento += resultado.faturamento;
+    somaTarifaCielo += resultado.faturamento * resultado.taxaCielo;
+    somaTarifaConc += resultado.faturamento * resultado.taxaConc;
   });
 
-  const corTotalMensal = totalMensal >= 0 ? "positivo" : "negativo";
-  const corTotalAnual = totalAnual >= 0 ? "positivo" : "negativo";
+  const totalAnual = totalMensal * 12;
+  const custoCieloAnual = totalCustoCieloMensal * 12;
+  const custoConcAnual = totalCustoConcMensal * 12;
 
-  html += `
-    <div class="card-total">
-      <h4>Resultado Total</h4>
-      <p class="valor ${corTotalMensal}">Diferença Mensal Total: ${totalMensal >= 0 ? "+" : "–"}R$ ${Math.abs(totalMensal).toFixed(2)}</p>
-      <p class="valor ${corTotalAnual}">Diferença Anual Total: ${totalAnual >= 0 ? "+" : "–"}R$ ${Math.abs(totalAnual).toFixed(2)}</p>
-    </div>
-  </div>`;
+  let fraseComparativa;
+  if (totalFaturamento > 0) {
+    const mediaCielo = somaTarifaCielo / totalFaturamento;
+    const mediaConc = somaTarifaConc / totalFaturamento;
+    const diferencaTaxa = mediaConc - mediaCielo;
+
+    if (Math.abs(diferencaTaxa) < 0.0001) {
+      fraseComparativa = "As taxas médias da Cielo e do concorrente estão iguais.";
+    } else {
+      const status = diferencaTaxa > 0 ? "maior" : "menor";
+      fraseComparativa = `A taxa do concorrente atual está ${Math.abs(diferencaTaxa).toFixed(2)} p.p. ${status} do que a da Cielo.`;
+    }
+  } else {
+    fraseComparativa = "Informe os valores de faturamento e taxa para comparar as propostas.";
+  }
+
+  const classeMensal = totalMensal >= 0 ? "positivo" : "negativo";
+  const classeAnual = totalAnual >= 0 ? "positivo" : "negativo";
+
+  const html = `
+    <div class="resumo-taxas-simples">
+      <div class="card-total">
+        <h4>Resultado Total</h4>
+        <p>Custo Cielo Mensal: <strong>R$ ${formatarMoeda(totalCustoCieloMensal)}</strong></p>
+        <p>Custo Concorrente Mensal: <strong>R$ ${formatarMoeda(totalCustoConcMensal)}</strong></p>
+        <p>Custo Cielo Anual: <strong>R$ ${formatarMoeda(custoCieloAnual)}</strong></p>
+        <p>Custo Concorrente Anual: <strong>R$ ${formatarMoeda(custoConcAnual)}</strong></p>
+        <p class="valor ${classeMensal}">Diferença Mensal Total: ${totalMensal >= 0 ? "+" : "–"}R$ ${formatarMoeda(Math.abs(totalMensal))}</p>
+        <p class="valor ${classeAnual}">Diferença Anual Total: ${totalAnual >= 0 ? "+" : "–"}R$ ${formatarMoeda(Math.abs(totalAnual))}</p>
+        <p class="frase-comparativa">${fraseComparativa}</p>
+      </div>
+    </div>`;
 
   document.getElementById(`resumo-${grupo}`).innerHTML = html;
 }
@@ -322,6 +330,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // 👉 ADICIONA ESSA LINHA AQUI:
   inicializarServicos();
+  inicializarPixMaquininha();
+  inicializarDemaisPix();
+  inicializarNegociacao();
 
   const fatMensal = document.getElementById("fat-mensal");
   const fatAnual = document.getElementById("fat-anual");
@@ -337,6 +348,14 @@ document.addEventListener("DOMContentLoaded", () => {
     selectRA.addEventListener("change", () => {
       window.possuiRA = selectRA.value;
     });
+  }
+
+  document.querySelectorAll('input[name="tipo-cliente"]').forEach(radio => {
+    radio.addEventListener("change", () => atualizarMensagemTipoCliente(radio.value));
+  });
+  const selecionado = document.querySelector('input[name="tipo-cliente"]:checked');
+  if (selecionado) {
+    atualizarMensagemTipoCliente(selecionado.value);
   }
 });
 
@@ -380,11 +399,39 @@ window.toggleSeção = function (id) {
 const servicosLista = [
   "Cesta de Serviços",
   "Cartão de Crédito: Anuidade",
-  "Pix na Máquina / Pix via QR Code",
   "Boletos: Tarifa de Registro",
   "Folha de Pagamento: Transmissão",
   "TED"
 ];
+
+const totaisSecoes = {
+  servicosDiversos: { mensal: 0, anual: 0 },
+  pixMaquininha: { mensal: 0, anual: 0 },
+  demaisPix: { mensal: 0, anual: 0 }
+};
+
+const pixMaquininhaDefaults = [
+  "Pix QR Code Estático",
+  "Pix QR Code Dinâmico"
+];
+
+const demaisServicosPixDefaults = [
+  "Pix Recebimento por Transferência",
+  "Pix Cobrança Online"
+];
+
+const negociacaoDefaults = [
+  "Cartões",
+  "Boletos",
+  "Pix",
+  "Outros"
+];
+
+const mensagensTipoCliente = {
+  Conquista: "A operação gera um novo resultado no quadro Cielo vs Nova destacando o ganho potencial para conquistar o cliente.",
+  Reconquista: "O comparativo Cielo vs Nova enfatiza o resultado esperado para reconquistar o cliente.",
+  Blindagem: "Os números apresentados reforçam o relacionamento atual para blindar o cliente na base Cielo."
+};
 
 function formatarInteiro(valor) {
   return Math.round(valor).toLocaleString("pt-BR");
@@ -464,6 +511,9 @@ function calcularServicos() {
   document.getElementById("total-ano").textContent = formatarInteiro(totalAno);
   document.getElementById("total-percentual").textContent = `${mediaPercentual.toFixed(1)}%`;
 
+  totaisSecoes.servicosDiversos.mensal = totalMes;
+  totaisSecoes.servicosDiversos.anual = totalAno;
+
   // Atualiza quadrantes visuais
   document.getElementById("resumo-serv-mes").textContent = formatarMoeda(totalMes);
   document.getElementById("resumo-serv-ano").textContent = formatarMoeda(totalAno);
@@ -494,11 +544,289 @@ function limparServicos() {
   document.getElementById("total-ano").textContent = "";
   document.getElementById("total-percentual").textContent = "";
 
+  totaisSecoes.servicosDiversos = { mensal: 0, anual: 0 };
+
   // Esconde o resumo visual de serviços (novidade)
   const boxResumo = document.getElementById("resultado-servicos");
   if (boxResumo) {
     boxResumo.style.display = "none";
   }
+}
+
+
+function adicionarLinhaPixMaquininha(nome = "") {
+  const tbody = document.getElementById("pix-maquininha-tbody");
+  if (!tbody) return;
+
+  const index = tbody.querySelectorAll("tr").length;
+  const linha = document.createElement("tr");
+  linha.innerHTML = `
+    <td><input type="text" name="pixm-servico-${index}" value="${nome}"></td>
+    <td><input type="number" step="0.01" name="pixm-volume-${index}"></td>
+    <td><input type="number" step="0.01" name="pixm-atual-${index}"></td>
+    <td><input type="number" step="0.01" name="pixm-proposto-${index}"></td>
+    <td><span id="pixm-mes-${index}"></span></td>
+    <td><span id="pixm-ano-${index}"></span></td>
+  `;
+  tbody.appendChild(linha);
+}
+
+function inicializarPixMaquininha() {
+  const tbody = document.getElementById("pix-maquininha-tbody");
+  if (!tbody) return;
+  if (tbody.children.length === 0) {
+    pixMaquininhaDefaults.forEach(nome => adicionarLinhaPixMaquininha(nome));
+  }
+}
+
+function calcularPixMaquininha() {
+  const tbody = document.getElementById("pix-maquininha-tbody");
+  if (!tbody) return;
+
+  let totalMensal = 0;
+
+  tbody.querySelectorAll("tr").forEach((linha, index) => {
+    const volume = parseFloat(linha.querySelector(`[name='pixm-volume-${index}']`)?.value || 0);
+    const tarifaAtual = parseFloat(linha.querySelector(`[name='pixm-atual-${index}']`)?.value || 0);
+    const tarifaProposta = parseFloat(linha.querySelector(`[name='pixm-proposto-${index}']`)?.value || 0);
+
+    const reducaoMensal = ((tarifaAtual - tarifaProposta) / 100) * volume;
+    const reducaoAnual = reducaoMensal * 12;
+
+    const spanMes = document.getElementById(`pixm-mes-${index}`);
+    const spanAno = document.getElementById(`pixm-ano-${index}`);
+    if (spanMes) spanMes.textContent = `${reducaoMensal >= 0 ? "" : "-"}${formatarMoeda(Math.abs(reducaoMensal))}`;
+    if (spanAno) spanAno.textContent = `${reducaoAnual >= 0 ? "" : "-"}${formatarMoeda(Math.abs(reducaoAnual))}`;
+
+    totalMensal += reducaoMensal;
+  });
+
+  const totalAnual = totalMensal * 12;
+
+  const totalMesSpan = document.getElementById("pix-maquininha-total-mes");
+  const totalAnoSpan = document.getElementById("pix-maquininha-total-ano");
+  if (totalMesSpan) totalMesSpan.textContent = formatarMoeda(totalMensal);
+  if (totalAnoSpan) totalAnoSpan.textContent = formatarMoeda(totalAnual);
+
+  totaisSecoes.pixMaquininha = { mensal: totalMensal, anual: totalAnual };
+
+  const resumo = document.getElementById("resultado-pix-maquininha");
+  if (resumo) {
+    const mostrar = Math.abs(totalMensal) > 0;
+    resumo.style.display = mostrar ? "flex" : "none";
+  }
+  const resumoMes = document.getElementById("resumo-pix-maquininha-mes");
+  const resumoAno = document.getElementById("resumo-pix-maquininha-ano");
+  if (resumoMes) resumoMes.textContent = formatarMoeda(totalMensal);
+  if (resumoAno) resumoAno.textContent = formatarMoeda(totalAnual);
+}
+
+function limparPixMaquininha() {
+  const tbody = document.getElementById("pix-maquininha-tbody");
+  if (tbody) {
+    tbody.querySelectorAll("input").forEach(input => { input.value = ""; });
+    tbody.querySelectorAll("span").forEach(span => { span.textContent = ""; });
+  }
+
+  const totalMesSpan = document.getElementById("pix-maquininha-total-mes");
+  const totalAnoSpan = document.getElementById("pix-maquininha-total-ano");
+  if (totalMesSpan) totalMesSpan.textContent = "0,00";
+  if (totalAnoSpan) totalAnoSpan.textContent = "0,00";
+
+  const resumo = document.getElementById("resultado-pix-maquininha");
+  if (resumo) resumo.style.display = "none";
+
+  totaisSecoes.pixMaquininha = { mensal: 0, anual: 0 };
+}
+
+
+function adicionarLinhaDemaisPix(nome = "") {
+  const tbody = document.getElementById("demais-pix-tbody");
+  if (!tbody) return;
+
+  const index = tbody.querySelectorAll("tr").length;
+  const linha = document.createElement("tr");
+  linha.innerHTML = `
+    <td><input type="text" name="demais-servico-${index}" value="${nome}"></td>
+    <td><input type="number" step="0.01" name="demais-volume-${index}"></td>
+    <td><input type="number" step="0.01" name="demais-qtd-${index}"></td>
+    <td><input type="number" step="0.01" name="demais-atual-${index}"></td>
+    <td><input type="number" step="0.01" name="demais-proposto-${index}"></td>
+    <td><span id="demais-mes-${index}"></span></td>
+    <td><span id="demais-ano-${index}"></span></td>
+  `;
+  tbody.appendChild(linha);
+}
+
+function inicializarDemaisPix() {
+  const tbody = document.getElementById("demais-pix-tbody");
+  if (!tbody) return;
+  if (tbody.children.length === 0) {
+    demaisServicosPixDefaults.forEach(nome => adicionarLinhaDemaisPix(nome));
+  }
+}
+
+function calcularDemaisServicosPix() {
+  const tbody = document.getElementById("demais-pix-tbody");
+  if (!tbody) return;
+
+  let totalQtd = 0;
+  let totalMensal = 0;
+
+  tbody.querySelectorAll("tr").forEach((linha, index) => {
+    const quantidade = parseFloat(linha.querySelector(`[name='demais-qtd-${index}']`)?.value || 0);
+    const valorAtual = parseFloat(linha.querySelector(`[name='demais-atual-${index}']`)?.value || 0);
+    const valorProposto = parseFloat(linha.querySelector(`[name='demais-proposto-${index}']`)?.value || 0);
+
+    const diferencaMensal = (valorAtual - valorProposto) * (quantidade || 1);
+    const diferencaAnual = diferencaMensal * 12;
+
+    totalQtd += quantidade || 0;
+    totalMensal += diferencaMensal;
+
+    const spanMes = document.getElementById(`demais-mes-${index}`);
+    const spanAno = document.getElementById(`demais-ano-${index}`);
+    if (spanMes) spanMes.textContent = `${diferencaMensal >= 0 ? "" : "-"}${formatarMoeda(Math.abs(diferencaMensal))}`;
+    if (spanAno) spanAno.textContent = `${diferencaAnual >= 0 ? "" : "-"}${formatarMoeda(Math.abs(diferencaAnual))}`;
+  });
+
+  const totalAnual = totalMensal * 12;
+
+  const totalQtdSpan = document.getElementById("demais-pix-total-qtd");
+  const totalMesSpan = document.getElementById("demais-pix-total-mes");
+  const totalAnoSpan = document.getElementById("demais-pix-total-ano");
+  if (totalQtdSpan) totalQtdSpan.textContent = formatarInteiro(totalQtd);
+  if (totalMesSpan) totalMesSpan.textContent = formatarMoeda(totalMensal);
+  if (totalAnoSpan) totalAnoSpan.textContent = formatarMoeda(totalAnual);
+
+  totaisSecoes.demaisPix = { mensal: totalMensal, anual: totalAnual };
+
+  const resumo = document.getElementById("resultado-demais-pix");
+  if (resumo) {
+    const mostrar = Math.abs(totalMensal) > 0;
+    resumo.style.display = mostrar ? "flex" : "none";
+  }
+  const resumoMes = document.getElementById("resumo-demais-pix-mes");
+  const resumoAno = document.getElementById("resumo-demais-pix-ano");
+  if (resumoMes) resumoMes.textContent = formatarMoeda(totalMensal);
+  if (resumoAno) resumoAno.textContent = formatarMoeda(totalAnual);
+}
+
+function limparDemaisServicosPix() {
+  const tbody = document.getElementById("demais-pix-tbody");
+  if (tbody) {
+    tbody.querySelectorAll("input").forEach(input => { input.value = ""; });
+    tbody.querySelectorAll("span").forEach(span => { span.textContent = ""; });
+  }
+
+  const totalQtdSpan = document.getElementById("demais-pix-total-qtd");
+  const totalMesSpan = document.getElementById("demais-pix-total-mes");
+  const totalAnoSpan = document.getElementById("demais-pix-total-ano");
+  if (totalQtdSpan) totalQtdSpan.textContent = "0";
+  if (totalMesSpan) totalMesSpan.textContent = "0,00";
+  if (totalAnoSpan) totalAnoSpan.textContent = "0,00";
+
+  const resumo = document.getElementById("resultado-demais-pix");
+  if (resumo) resumo.style.display = "none";
+
+  totaisSecoes.demaisPix = { mensal: 0, anual: 0 };
+}
+
+
+function adicionarLinhaNegociacao(item = "") {
+  const tbody = document.getElementById("negociacao-tbody");
+  if (!tbody) return;
+
+  const index = tbody.querySelectorAll("tr").length;
+  const linha = document.createElement("tr");
+  linha.innerHTML = `
+    <td><input type="text" name="neg-item-${index}" value="${item}"></td>
+    <td><input type="number" step="0.01" name="neg-mes-${index}"></td>
+    <td><input type="text" name="neg-ano-${index}" disabled></td>
+  `;
+
+  const inputMes = linha.querySelector(`[name='neg-mes-${index}']`);
+  if (inputMes) {
+    inputMes.addEventListener("input", () => atualizarLinhaNegociacao(index));
+  }
+
+  tbody.appendChild(linha);
+}
+
+function inicializarNegociacao() {
+  const tbody = document.getElementById("negociacao-tbody");
+  if (!tbody) return;
+  if (tbody.children.length === 0) {
+    negociacaoDefaults.forEach(item => adicionarLinhaNegociacao(item));
+  }
+}
+
+function atualizarLinhaNegociacao(index) {
+  const mensal = parseFloat(document.querySelector(`[name='neg-mes-${index}']`)?.value || 0);
+  const campoAno = document.querySelector(`[name='neg-ano-${index}']`);
+  if (campoAno) {
+    campoAno.value = `R$ ${formatarMoeda(mensal * 12)}`;
+  }
+}
+
+function calcularNegociacao() {
+  const tbody = document.getElementById("negociacao-tbody");
+  if (!tbody) return;
+
+  let totalMensal = 0;
+
+  tbody.querySelectorAll("tr").forEach((_, index) => {
+    const mensal = parseFloat(document.querySelector(`[name='neg-mes-${index}']`)?.value || 0);
+    totalMensal += mensal;
+    atualizarLinhaNegociacao(index);
+  });
+
+  const totalAnual = totalMensal * 12;
+
+  const totalMesSpan = document.getElementById("negociacao-total-mes");
+  const totalAnoSpan = document.getElementById("negociacao-total-ano");
+  if (totalMesSpan) totalMesSpan.textContent = formatarMoeda(totalMensal);
+  if (totalAnoSpan) totalAnoSpan.textContent = formatarMoeda(totalAnual);
+}
+
+function limparNegociacao() {
+  const tbody = document.getElementById("negociacao-tbody");
+  if (tbody) {
+    tbody.querySelectorAll("input[type='number']").forEach(input => { input.value = ""; });
+    tbody.querySelectorAll("input[disabled]").forEach(input => { input.value = ""; });
+  }
+
+  const totalMesSpan = document.getElementById("negociacao-total-mes");
+  const totalAnoSpan = document.getElementById("negociacao-total-ano");
+  if (totalMesSpan) totalMesSpan.textContent = "0,00";
+  if (totalAnoSpan) totalAnoSpan.textContent = "0,00";
+}
+
+
+function calcularConsolidado() {
+  const totalMensal = totaisSecoes.servicosDiversos.mensal + totaisSecoes.pixMaquininha.mensal + totaisSecoes.demaisPix.mensal;
+  const totalAnual = totaisSecoes.servicosDiversos.anual + totaisSecoes.pixMaquininha.anual + totaisSecoes.demaisPix.anual;
+
+  const spanMensal = document.getElementById("consolidado-mensal");
+  const spanAnual = document.getElementById("consolidado-anual");
+  if (spanMensal) spanMensal.textContent = formatarMoeda(totalMensal);
+  if (spanAnual) spanAnual.textContent = formatarMoeda(totalAnual);
+
+  const bloco = document.getElementById("resultado-consolidado");
+  if (bloco) {
+    const mostrar = Math.abs(totalMensal) > 0 || Math.abs(totalAnual) > 0;
+    bloco.style.display = mostrar ? "flex" : "none";
+  }
+}
+
+function limparConsolidado() {
+  const spanMensal = document.getElementById("consolidado-mensal");
+  const spanAnual = document.getElementById("consolidado-anual");
+  if (spanMensal) spanMensal.textContent = "0,00";
+  if (spanAnual) spanAnual.textContent = "0,00";
+
+  const bloco = document.getElementById("resultado-consolidado");
+  if (bloco) bloco.style.display = "none";
 }
 
 
@@ -662,6 +990,10 @@ function calcularResumoFinal() {
   calcularResumo("credito");
   calcularEquipamentos();
   calcularServicos();
+  calcularPixMaquininha();
+  calcularDemaisServicosPix();
+  calcularConsolidado();
+  calcularNegociacao();
   calcularInvestFacil();
 
   const gruposValidos = ["debito", "credito"];
@@ -707,7 +1039,9 @@ function calcularResumoFinal() {
   const atualServ = parseFloat((document.getElementById("total-atual")?.textContent || "0").replace(/\./g, "").replace(",", "."));
   const propServ = parseFloat((document.getElementById("total-proposto")?.textContent || "0").replace(/\./g, "").replace(",", "."));
   const mesServ = parseFloat((document.getElementById("total-mes")?.textContent || "0").replace(/\./g, "").replace(",", "."));
-  const anoServ = parseFloat((document.getElementById("total-ano")?.textContent || "0").replace(/\./g, "").replace(",", "."));
+
+  const totalServicosMensal = totaisSecoes.servicosDiversos.mensal + totaisSecoes.pixMaquininha.mensal + totaisSecoes.demaisPix.mensal;
+  const totalServicosAnual = totaisSecoes.servicosDiversos.anual + totaisSecoes.pixMaquininha.anual + totaisSecoes.demaisPix.anual;
 
   const pegarTextoSpan = id => parseFloat((document.getElementById(id)?.textContent || "0").replace(/\./g, "").replace(",", "."));
   const repM = pegarTextoSpan("repasse-mes");
@@ -725,15 +1059,21 @@ function calcularResumoFinal() {
   const gdadMes = limparInputComRS("gdad-mes");
   const gdadAno = limparInputComRS("gdad-ano");
 
-  const cliente_mensal = totalMensalTaxas + difEquip - mesServ;
-  const cliente_anual = (totalMensalTaxas * 12) + difEquip - (mesServ * 12);
+  const cliente_mensal = totalMensalTaxas + difEquip - totalServicosMensal;
+  const cliente_anual = (totalMensalTaxas * 12) + difEquip - totalServicosAnual;
 
   const empresa = document.getElementById("nome-empresa")?.value || "Cliente não informado";
 
-  const corCliente = cliente_mensal >= 0 ? "#28a745" : "#dc3545";
-  const textoCliente = cliente_mensal <= 0 ? "redução" : "elevação";
+  const classeValorTotal = cliente_mensal === 0 ? "neutro" : (cliente_mensal < 0 ? "positivo" : "negativo");
 
   const html = `
+  <div id="bloco-resultado-total" class="resumo-cliente destaque-resultado-final" style="margin-bottom: 24px; text-align: center;">
+    <p style="font-size: 1.1rem; margin-bottom: 10px;">
+      Para o cliente <strong id="nome-cliente-final">${empresa}</strong>, o resultado total projetado considerando todas as seções é:
+    </p>
+    <p id="valor-total-final" class="valor-total-final ${classeValorTotal}">R$ ${formatarMoedaResumo(Math.abs(cliente_anual))}</p>
+  </div>
+
   <div class="resumo-linha">
     <div class="resumo-card bg-taxas">
       <h4>📊 Comparativo de Taxas</h4>
@@ -765,13 +1105,16 @@ function calcularResumoFinal() {
   <div class="resumo-linha">
     <div class="resumo-card bg-servicos">
       <h4>🧾 Produtos e Serviços</h4>
-      <p>Custo Atual: <strong>${formatarMoedaResumo(atualServ)}</strong></p>
-      <p>Custo Proposto: <strong>${formatarMoedaResumo(propServ)}</strong></p>
-      <p>Total Mensal: <strong>${formatarMoedaResumo(mesServ)}</strong></p>
-      <p>Total Anual: <strong>${formatarMoedaResumo(anoServ)}</strong></p>
+      <p>Custo Atual (Diversos): <strong>${formatarMoedaResumo(atualServ)}</strong></p>
+      <p>Custo Proposto (Diversos): <strong>${formatarMoedaResumo(propServ)}</strong></p>
+      <p>Redução Diversos (Mês): <strong>${formatarMoedaResumo(mesServ)}</strong></p>
+      <p>Pix na Maquininha (Mês): <strong>${formatarMoedaResumo(totaisSecoes.pixMaquininha.mensal)}</strong></p>
+      <p>Demais Serviços Pix (Mês): <strong>${formatarMoedaResumo(totaisSecoes.demaisPix.mensal)}</strong></p>
+      <p><strong>Total Mensal Consolidado: ${formatarMoedaResumo(totalServicosMensal)}</strong></p>
+      <p><strong>Total Anual Consolidado: ${formatarMoedaResumo(totalServicosAnual)}</strong></p>
       <p style="margin-top: 10px;">
-        A proposta apresenta uma <strong>${mesServ > 0 ? "redução" : "elevação"}</strong> de 
-        <strong>${formatarMoedaResumo(Math.abs(mesServ))}</strong> por mês nos produtos/serviços contratados.
+        A proposta apresenta uma <strong>${totalServicosMensal >= 0 ? "redução" : "elevação"}</strong> de
+        <strong>${formatarMoedaResumo(Math.abs(totalServicosMensal))}</strong> por mês considerando todos os serviços.
       </p>
     </div>
 
@@ -796,47 +1139,45 @@ function calcularResumoFinal() {
     </div>
   </div>
 
-  <div id="bloco-resultado-total" class="resumo-cliente destaque-resultado-final" style="margin-top: 30px; text-align: center;">
-    <p style="font-size: 1.1rem; margin-bottom: 10px;">
-      Para o cliente <strong id="nome-cliente-final">${empresa}</strong>, temos o seguinte cenário:
-    </p>
+  ${
+    document.getElementById("visao-grupo")?.checked ? (() => {
+      const getListItems = (selector) =>
+        [...document.querySelectorAll(selector)]
+          .map(el => `<li>${el.childNodes[0].textContent.trim()}</li>`)
+          .join("");
 
-    ${
-      document.getElementById("visao-grupo")?.checked ? (() => {
-        const getListItems = (selector) =>
-          [...document.querySelectorAll(selector)]
-            .map(el => `<li>${el.childNodes[0].textContent.trim()}</li>`)
-            .join("");
+      const cnpjs = getListItems("#lista-cnpjs .composicao-item");
+      const agencias = getListItems("#lista-agencias .composicao-item");
+      const contas = getListItems("#lista-contas .composicao-item");
 
-        const cnpjs = getListItems("#lista-cnpjs .composicao-item");
-        const agencias = getListItems("#lista-agencias .composicao-item");
-        const contas = getListItems("#lista-contas .composicao-item");
+      if (!cnpjs && !agencias && !contas) return "";
 
-        if (!cnpjs && !agencias && !contas) return "";
-
-        return `
-          <div class="resumo-grupo-container">
+      return `
+        <div class="resumo-cliente destaque-resultado-final" style="margin-top: 30px; text-align: center;">
+          <p style=\"font-size: 1rem; margin-bottom: 12px;\">Composição informada para o grupo econômico:</p>
+          <div class=\"resumo-grupo-container\">
             ${cnpjs ? `
-              <div class="resumo-grupo-card">
+              <div class=\"resumo-grupo-card\">
                 <h4>📄 CNPJs do Grupo</h4>
                 <ul>${cnpjs}</ul>
               </div>` : ""}
             ${agencias ? `
-              <div class="resumo-grupo-card">
+              <div class=\"resumo-grupo-card\">
                 <h4>🏦 Agências</h4>
                 <ul>${agencias}</ul>
               </div>` : ""}
             ${contas ? `
-              <div class="resumo-grupo-card">
+              <div class=\"resumo-grupo-card\">
                 <h4>💳 Contas</h4>
                 <ul>${contas}</ul>
               </div>` : ""}
           </div>
-        `;
-      })() : ""
-    }
+        </div>
+      `;
+    })() : ""
+  }
 
-    <div class="resumo-linha">
+  <div class="resumo-linha">
       <div class="resumo-card bg-servicos">
         <h4>👤 Visão do Cliente</h4>
         <p><strong>Custo Final:</strong> Houve uma ${cliente_mensal < 0 ? "redução" : "elevação"} de 
@@ -966,6 +1307,18 @@ function limparTudo() {
   });
 }
 
+
+
+
+
+function atualizarMensagemTipoCliente(valor) {
+  const container = document.getElementById("mensagem-tipo-cliente");
+  if (!container) return;
+
+  const mensagem = mensagensTipoCliente[valor] || "";
+  container.textContent = mensagem;
+  container.style.display = mensagem ? "block" : "none";
+}
 
 
 document.querySelectorAll('input[name="tipo-visao"]').forEach(radio => {

--- a/Nova pasta/style.css
+++ b/Nova pasta/style.css
@@ -69,14 +69,6 @@ body {
   margin-bottom: 40px;
 }
 
-/* Seção 7 - GDAD (Verde Água Suave) */
-.bg-gdad {
-  background-color: #f3fbfb; /* verde-água bem claro */
-  padding: 30px;
-  border-radius: 12px;
-  margin-bottom: 40px;
-}
-
 h1 {
   text-align: center;
   margin-bottom: 30px;
@@ -138,6 +130,40 @@ h2 {
   padding: 30px;
   border-radius: 16px;
   margin-bottom: 40px;
+}
+
+.resultado-taxas-box {
+  display: none;
+  justify-content: center;
+  margin-top: 24px;
+}
+
+.quadrante-taxa.total {
+  background: #eef7f0;
+  border-radius: 14px;
+  padding: 24px 32px;
+  text-align: center;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+  max-width: 360px;
+  width: 100%;
+}
+
+.quadrante-taxa.total h4 {
+  color: #1b5e20;
+  margin-bottom: 12px;
+  font-size: 1.1rem;
+}
+
+.quadrante-taxa.total p {
+  margin-bottom: 6px;
+  font-size: 0.95rem;
+  color: #24404f;
+}
+
+.mensagem-resumo-taxas {
+  margin-top: 12px;
+  font-size: 0.9rem;
+  color: #2f4858;
 }
 
 /* Tabelas comparativas */
@@ -592,11 +618,6 @@ input[disabled] {
   display: none; /* MANTÉM OCULTO por padrão */
 }
 
-.resumo-gdad {
-  background-color: #f3fbfb; /* azul claro para destacar GDAD */
-}
-
-
 .quadrante-invest {
   flex: 1;
   min-width: 240px;
@@ -673,6 +694,15 @@ input[disabled] {
   transition: all 0.3s ease-in-out;
 }
 
+.resumo-placeholder {
+  font-size: 0.95rem;
+  color: #4b5b6d;
+  background: #f0f4f8;
+  border-radius: 10px;
+  padding: 18px 22px;
+  border-left: 4px solid #5b8def;
+}
+
 /* ==== RESUMO FINAL DESTACADO ==== */
 .resumo-destacado {
   margin-top: 30px;
@@ -746,6 +776,36 @@ input[disabled] {
   font-size: 0.95rem;
   margin-bottom: 6px;
   line-height: 1.4;
+}
+
+.destaque-diferenca {
+  margin-top: 8px;
+  font-weight: 600;
+  color: #003366;
+}
+
+.mensagem-comparativo {
+  margin-top: 6px;
+  font-size: 0.9rem;
+  color: #4a5a6a;
+}
+
+.texto-mensal-equivalente {
+  font-size: 0.9rem;
+  color: #4b5b6d;
+  margin-top: 6px;
+}
+
+.negociacao-card {
+  background-color: #fff5eb;
+  border: 1px solid #ffd7a3;
+}
+
+.nota-saldo {
+  display: block;
+  font-size: 0.75rem;
+  color: #526173;
+  margin-top: 6px;
 }
 
 .resumo-cliente {

--- a/Nova pasta/style.css
+++ b/Nova pasta/style.css
@@ -257,6 +257,86 @@ input[disabled] {
   background-color: #dc3545;
 }
 
+.add-btn.azul {
+  background-color: #0056d6;
+}
+
+.campo-ajuda {
+  font-size: 0.85rem;
+  color: #4a5a6a;
+  margin-top: -6px;
+  margin-bottom: 12px;
+}
+
+.alerta-tipo-cliente {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 8px;
+  background-color: #e8f4ff;
+  color: #003366;
+  font-size: 0.95rem;
+  display: none;
+}
+
+.descricao-secao {
+  font-size: 0.9rem;
+  color: #4b5b6d;
+  margin-bottom: 18px;
+}
+
+.form-actions.linha-add {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.tabela-pix th,
+.tabela-pix td {
+  text-align: center;
+}
+
+.resumo-pix {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-top: 20px;
+}
+
+.resumo-pix .resumo-card {
+  flex: 1;
+  min-width: 220px;
+}
+
+.resumo-taxas-simples {
+  display: flex;
+  justify-content: center;
+}
+
+.resumo-taxas-simples .card-total {
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  max-width: 420px;
+  width: 100%;
+}
+
+.resumo-taxas-simples .card-total h4 {
+  margin-bottom: 16px;
+  color: #003366;
+}
+
+.resumo-taxas-simples .card-total p {
+  margin-bottom: 8px;
+  font-size: 0.95rem;
+}
+
+.frase-comparativa {
+  margin-top: 14px;
+  font-weight: 600;
+  color: #003366;
+}
+
 .remove-btn {
   background-color: #dc3545;
   border: none;


### PR DESCRIPTION
## Summary
- update the empresa header section with the negotiated faturamento helper text and contextual guidance for the tipo de cliente toggle
- simplify the taxa comparison outputs to focus on the total resultado and weighted difference between Cielo and concorrente
- add editable Pix na Maquininha, Demais Serviços Pix, consolidação e negociação sections with automatic month and year calculations, and surface their totals in the resumo final

## Testing
- no automated tests were run (static front-end changes)


------
https://chatgpt.com/codex/tasks/task_e_68d5defe5b88833195aa407ee5311b9a